### PR TITLE
Update Plugin for 2023.3-EAP1 & Improve JDK Compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 23.09.28XX
+- Support for 2023.3 EAP
+
 ## 23.02.20XX
 - Support for 2023.1
 

--- a/README.md
+++ b/README.md
@@ -2,3 +2,21 @@
 
 [![Version](https://img.shields.io/jetbrains/plugin/v/com.jetbrains.rider.plugins.mockingspongebob)](https://plugins.jetbrains.com/plugin/18355-mocking-spongebob)
 [![ReSharper](https://img.shields.io/resharper/v/ca.nosuchcompany.mockingspongebobplugin)](https://plugins.jetbrains.com/plugin/18356-mocking-spongebob)
+
+**How to run on Windows**
+
+- Open the solution `NoSuchCompany.MockingSpongebobPlugin.sln` in Visual Studio;
+- Make sure there is a valid NuGet feed configured (`https://api.nuget.org/v3/index.json`);
+- Open a command prompt in Powershell;
+- Run the command `./buildPlugin.ps1` (you might need to remove the Rider project if it causes the build to fail);
+- Run the command `./runVisualStudio.ps1` (you might need to remove the Rider project if it causes the build to fail);
+
+At this point, another instance of Visual Studio should have been started.
+Go into ReSharper > Extension Manager and look for the Mocking Spongebob extension plugin. It should be installed and have the version `9999.0`.
+
+**How to run on macOS**
+
+- Run the command `./gradlew :runIde` in a terminal window
+
+
+

--- a/build.gradle
+++ b/build.gradle
@@ -2,10 +2,10 @@
 import org.apache.tools.ant.taskdefs.condition.Os
 
 plugins {
-     id 'java'
-     id 'org.jetbrains.kotlin.jvm' version '1.8.21'  //  https://plugins.gradle.org/plugin/org.jetbrains.kotlin.jvm/1.8.21
-     id 'org.jetbrains.intellij' version '1.14.0'      // https://github.com/JetBrains/gradle-intellij-plugin/releases
-     id 'com.jetbrains.rdgen' version '2023.2.1'     // https://www.myget.org/feed/rd-snapshots/package/maven/com.jetbrains.rd/rd-gen
+    id 'java'
+    id 'org.jetbrains.kotlin.jvm' version '1.9.0'  //  https://plugins.gradle.org/plugin/org.jetbrains.kotlin.jvm/1.8.21
+    id 'org.jetbrains.intellij' version '1.15.0'      // https://github.com/JetBrains/gradle-intellij-plugin/releases
+    id 'com.jetbrains.rdgen' version '2023.3.0'     // https://www.myget.org/feed/rd-snapshots/package/maven/com.jetbrains.rd/rd-gen
 }
 
 ext {
@@ -21,7 +21,7 @@ repositories {
 }
 
 wrapper {
-    gradleVersion = '8.1.1'
+    gradleVersion = '8.2.1'     //  https://services.gradle.org/distributions/
     distributionType = Wrapper.DistributionType.ALL
     distributionUrl = "https://cache-redirector.jetbrains.com/services.gradle.org/distributions/gradle-${gradleVersion}-all.zip"
 }
@@ -38,6 +38,10 @@ sourceSets {
 
 compileKotlin {
     kotlinOptions { jvmTarget = "17" }
+}
+
+compileJava {
+    targetCompatibility = "17"
 }
 
 task setBuildTool {

--- a/devops/cicd/stages/build.yaml
+++ b/devops/cicd/stages/build.yaml
@@ -33,6 +33,18 @@ stages:
             inputs:
               version: 6.x
 
+          - task: JavaToolInstaller@0
+            inputs:
+              versionSpec: '17'
+              jdkArchitectureOption: 'x64'
+              jdkSourceOption: 'AzureStorage'
+              azureResourceManagerEndpoint: 'Azure (plugin-rider-pipeline)'
+              azureStorageAccountName: 'stpluginriderpipeline'
+              azureContainerName: 'jdk17'
+              azureCommonVirtualFile: 'jdk17.zip'
+              jdkDestinationDirectory: $(Agent.ToolsDirectory)/jdk
+              cleanDestinationDirectory: true
+
           - task: Bash@3
             displayName: 'update version (gradle & plugin.xml)'
             inputs:
@@ -46,8 +58,9 @@ stages:
               options: '-PPluginVersion=$(Build.BuildNumber)'
               tasks: ':prepareSandbox'
               publishJUnitResults: false
-              jdkVersionOption: 1.17
-          
+              javaHomeOption: 'Path'
+              jdkDirectory: $(Agent.ToolsDirectory)/jdk/JAVA_HOME_17_X64_jdk17_zip
+
           - task: CopyFiles@2
             displayName: 'copy .jar file'
             inputs:

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ PublishToken="_PLACEHOLDER_"
 #   Release:  2020.2
 #   Nightly:  2020.3-SNAPSHOT
 #   EAP:      2020.3-EAP2-SNAPSHOT
-ProductVersion=2023.2-EAP2-SNAPSHOT
+ProductVersion=2023.3-EAP1-SNAPSHOT
 
 # Kotlin 1.4 will bundle the stdlib dependency by default, causing problems with the version bundled with the IDE
 # https://blog.jetbrains.com/kotlin/2020/07/kotlin-1-4-rc-released/#stdlib-default

--- a/src/dotnet/Plugin.props
+++ b/src/dotnet/Plugin.props
@@ -1,7 +1,7 @@
 ﻿<Project>
 
   <PropertyGroup>
-    <SdkVersion>2023.3.0-EAP1</SdkVersion>
+    <SdkVersion>2023.3.0-EAP01</SdkVersion>
 
     <Title>Mocking Spongebob</Title>
     <Description>The plugin provides the ability to make comments a tiny bit more sarcastic as Mocking Spongebob would do.</Description>

--- a/src/dotnet/Plugin.props
+++ b/src/dotnet/Plugin.props
@@ -1,7 +1,7 @@
 ﻿<Project>
 
   <PropertyGroup>
-    <SdkVersion>2023.2.0-EAP02</SdkVersion>
+    <SdkVersion>2023.3.0-EAP1</SdkVersion>
 
     <Title>Mocking Spongebob</Title>
     <Description>The plugin provides the ability to make comments a tiny bit more sarcastic as Mocking Spongebob would do.</Description>


### PR DESCRIPTION
Updated plugin version to 2023.3-EAP1 in gradle.properties and Plugin.props for compatibility with the newly released 2023.3 EAP. Readme.md now contains instructions on how to run the plugin on Windows and macOS. Gradle version updated to 8.2.1 and Kotlin JVM version updated to 1.9.0 in build.gradle to stay up-to-date. JDK compatibility target was set to 17 in build.gradle and JavaToolInstaller was added in build.yaml to handle Java 17. Changelog.md was updated to track these updates.